### PR TITLE
Add Company Ruby On Remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A curated list of awesome [remote working](http://en.wikipedia.org/wiki/Telecomm
   1. [Remote OK](http://remoteok.io/) - scrapes many job board feeds for remote positions
   1. [RemoteWorkHunt] (http://www.remoteworkhunt.com/)
   1. [Remotive Jobs](http://jobs.remotive.io/)
+  1. [Ruby On Remote]((https://rubyonremote.com/) - aggregates remote jobs for Ruby developers
   2. [Virtual Vocations](http://www.virtualvocations.com/)
   1. [WFH.io](https://www.wfh.io/)
   1. [Working Nomads](http://www.workingnomads.co/jobs)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ A curated list of awesome [remote working](http://en.wikipedia.org/wiki/Telecomm
   1. [Remote OK](http://remoteok.io/) - scrapes many job board feeds for remote positions
   1. [RemoteWorkHunt] (http://www.remoteworkhunt.com/)
   1. [Remotive Jobs](http://jobs.remotive.io/)
-  1. [Ruby On Remote]((https://rubyonremote.com/) - aggregates remote jobs for Ruby developers
+  1. [Ruby On Remote](https://rubyonremote.com/) - aggregates remote jobs for Ruby developers
   2. [Virtual Vocations](http://www.virtualvocations.com/)
   1. [WFH.io](https://www.wfh.io/)
   1. [Working Nomads](http://www.workingnomads.co/jobs)


### PR DESCRIPTION
Ruby On Remote (https://rubyonremote.com/) aggregates Remote jobs for Ruby developers

I have added the company to the Job Boards section.